### PR TITLE
Change create_path to be platform-independent

### DIFF
--- a/fewshot/path_helper.py
+++ b/fewshot/path_helper.py
@@ -3,10 +3,11 @@ import os
 import pathlib
 
 
-def check_path(pathname: str) -> bool:
-    newdir = "/".join(pathname.split("/")[:-1])
-    if not os.path.exists(newdir):
-        os.makedirs(newdir)
+def create_path(pathname: str) -> None:
+    """Creates the directory for the given path if it doesn't already exist."""
+    dir = str(pathlib.Path(pathname).parent)
+    if not os.path.exists(dir):
+        os.makedirs(dir)
 
 
 def fewshot_filename(*paths) -> str:


### PR DESCRIPTION
The "/" separator isn't the same for every system.  Since we're already using pathlib, continue to use here.  I also changed the name and added a comment to make it clearer what this function does.

(Auto-formatter deleted some whitespace.)